### PR TITLE
feat: use additionalProperties=false

### DIFF
--- a/src/lib/json-schema/state.ts
+++ b/src/lib/json-schema/state.ts
@@ -79,6 +79,7 @@ export function propertyBuilderStateToSchema(
 			return {
 				type: state.isNullable ? ['object', 'null'] : 'object',
 				description: state.description,
+				additionalProperties: false,
 				properties: Object.fromEntries(
 					state.children.map(child => [
 						child.key,

--- a/src/lib/json-schema/types.ts
+++ b/src/lib/json-schema/types.ts
@@ -35,6 +35,7 @@ type ArrayType = {
 type ObjectType = {
 	type: ['object', 'null'] | 'object';
 	properties: Record<string, PropertySchema>;
+	additionalProperties?: boolean;
 };
 
 export { ArrayType, BooleanType, NumberType, ObjectType, StringType };


### PR DESCRIPTION
This makes it so that objects defined in JSON schema will automatically be given the additionalProperties: false field which means they’ll fail validation if there are unknown properties
