### PR TITLE
chore: improve err message on adding property when sibling has empty string key

### DIFF
--- a/src/lib/json-schema/builder.ts
+++ b/src/lib/json-schema/builder.ts
@@ -65,7 +65,11 @@ export function createJSONSchemaBuilder() {
 					child => child.key === property.key
 				);
 				if (parentHasChildWithSameKey) {
-					throw new Error(`Parent already has child with key ${property.key}`);
+					if (property.key === '') {
+						throw new Error('Parent have an unnamed property. Please give it a name before adding another property');
+					} else {
+						throw new Error(`Parent already has child with key ${property.key}`);
+					}
 				}
 
 				parentState.children.push(property);


### PR DESCRIPTION
# Improve error message for duplicate empty property keys

## Small UX Issue
When users try to add multiple properties to an object without naming them first, they encounter an unclear error message. The system uses empty strings as initial keys for new properties, and when attempting to add a second unnamed property, it throws a generic error: "Parent already has child with key".

https://github.com/user-attachments/assets/5d419d5a-acf1-414e-8964-e2b05834e3b1

## Proposed Improvement
Enhanced the error message in `addProperty` function to provide more specific and actionable feedback when dealing with empty string keys.

https://github.com/user-attachments/assets/291927b3-cfbe-4a4f-b227-54f52b2cb2c7


